### PR TITLE
SubmitCheckError should not send nil to ErrChan.

### DIFF
--- a/goworkers.go
+++ b/goworkers.go
@@ -169,9 +169,11 @@ func (gw *GoWorkers) SubmitCheckError(job func() error) {
 	atomic.AddUint32(&gw.qnumJobs, 1)
 	gw.jobQ <- func() {
 		err := job()
-		select {
-		case gw.ErrChan <- err:
-		default:
+		if err != nil {
+			select {
+			case gw.ErrChan <- err:
+			default:
+			}
 		}
 	}
 }

--- a/goworkers_test.go
+++ b/goworkers_test.go
@@ -288,6 +288,28 @@ func TestSubmitCheckResultAfterStop(t *testing.T) {
 	gw.SubmitCheckResult(func() (interface{}, error) { return nil, nil })
 }
 
+func TestSubmitCheckErrorNotSendNilToErrChan(t *testing.T) {
+	gw := New()
+	defer gw.Stop()
+
+	done := make(chan struct{})
+	job := func() error {
+		defer close(done)
+		return nil
+	}
+
+	gw.SubmitCheckError(job)
+	<-done
+
+	select {
+	case err := <-gw.ErrChan:
+		if err == nil {
+			t.Errorf("[want] Shuold not recv nil [got] Recv nil")
+		}
+	default:
+	}
+}
+
 func TestSubmitCheckErrorUnreadChan(t *testing.T) {
 	gw := New()
 


### PR DESCRIPTION
Hi 😄 
This fixes SubmitCheckError() not send nil to ErrChan.
Your library is very useful. Keep up the good work 👍 